### PR TITLE
Fix comma for backup_time metric.

### DIFF
--- a/backup_reporter/dataclass.py
+++ b/backup_reporter/dataclass.py
@@ -67,7 +67,7 @@ class BackupMetadata:
 
         prom_lines.append("# HELP backup_time Time when backup upload")
         prom_lines.append("# TYPE backup_time gauge")
-        prom_lines.append(f"backup_time{{customer='{self.customer}'}} {self.time}")
+        prom_lines.append(f'backup_time{{customer="{self.customer}"}} {self.time}')
 
         if self.last_backup_date:
             # если строка формата ISO8601


### PR DESCRIPTION
Исправление одинарной кавычки на двойную для метрики backup_time. Для обхода ошибки обработки метрик экспортером.